### PR TITLE
set close_timeout to 1 second so that websockets close more quickly

### DIFF
--- a/runware/server.py
+++ b/runware/server.py
@@ -58,6 +58,8 @@ class RunwareServer(RunwareBase):
 
         try:
             self._ws = await websockets.connect(self._url)
+            # update close_timeout so that we end the script sooner for inference examples
+            self._ws.close_timeout = 1
             self.logger.info(f"Connected to WebSocket URL: {self._url}")
 
             async def on_open(ws):


### PR DESCRIPTION
This brings the time down from:

```
real    0m12.882s
user    0m0.063s
sys     0m0.016s
```

to:

```
real    0m4.067s
user    0m0.056s
sys     0m0.021s
```

round-trip time incl websocket connect & closure (from central america)