### PR TITLE
Unexpected error when calling promptEnhance() without the promptMaxLe…

### DIFF
--- a/runware/base.py
+++ b/runware/base.py
@@ -604,7 +604,8 @@ class RunwareBase:
         :return: A list of IEnhancedPrompt objects representing the enhanced versions of the prompt.
         """
         prompt = promptEnhancer.prompt
-        promptMaxLength = promptEnhancer.promptMaxLength or 380
+        promptMaxLength = getattr(promptEnhancer, 'promptMaxLength', 380)
+
         promptVersions = promptEnhancer.promptVersions or 1
 
         taskUUID = getUUID()


### PR DESCRIPTION
…ngth param: "AttributeError: 'IPromptEnhance' object has no attribute 'promptMaxLength'