### PR TITLE
Add a helper method to instantiate dataclasses and filter out unknownattributes to maintain forward-compatibility with new API return values

### DIFF
--- a/runware/base.py
+++ b/runware/base.py
@@ -24,6 +24,7 @@ from .utils import (
     createImageFromResponse,
     createImageToTextFromResponse,
     createEnhancedPromptsFromResponse,
+    instantiateDataclassList,
     RunwareAPIError,
     RunwareError,
 )
@@ -345,7 +346,7 @@ class RunwareBase:
                 # This indicates an error response
                 raise RunwareAPIError(images)
 
-            return [IImage(**image_data) for image_data in images]
+            return instantiateDataclassList(IImage, images)
 
         # return images
 
@@ -823,7 +824,7 @@ class RunwareBase:
                 if images:
                     self._globalImages.extend(images)
                     try:
-                        partial_images = [IImage(**image_data) for image_data in images]
+                        partial_images = instantiateDataclassList(IImage, images)
                         if onPartialImages:
                             onPartialImages(
                                 partial_images, None

--- a/runware/utils.py
+++ b/runware/utils.py
@@ -8,7 +8,7 @@ import json
 import mimetypes
 import inspect
 from functools import reduce
-from typing import Any, Callable, Dict, List, Union, Optional, TypeVar
+from typing import Any, Callable, Dict, List, Union, Optional, TypeVar, Type
 from enum import Enum
 from dataclasses import dataclass, fields
 from .types import (
@@ -732,3 +732,23 @@ async def getIntervalWithPromise(
             logger.debug(f"Timeout canceled for {debugKey}")
 
     return await future
+
+def instantiateDataclassList(dataclass_type: Type[Any], data_list: List[dict]) -> List[Any]:
+    """
+    Instantiates a list of dataclass objects from a list of dictionaries,
+    filtering out any unknown attributes.
+
+    :param dataclass_type: The dataclass type to instantiate.
+    :param data_list: A list of dictionaries with data.
+    :return: A list of instantiated dataclass objects.
+    """
+    # Get the set of valid field names for the dataclass
+    valid_fields = {f.name for f in fields(dataclass_type)}
+    
+    instances = []
+    for data in data_list:
+        # Filter the data to include only valid fields
+        filtered_data = {k: v for k, v in data.items() if k in valid_fields}
+        instance = dataclass_type(**filtered_data)
+        instances.append(instance)
+    return instances


### PR DESCRIPTION
This helps to avoid attribute errors when we return new fields in a response, allowing compatibility with older deployments.