### PR TITLE
RD-483: [Python SDK] imageInference() with maskImage pointing to a lo…

### DIFF
--- a/runware/base.py
+++ b/runware/base.py
@@ -787,6 +787,9 @@ class RunwareBase:
             raise e
 
     def _isLocalFile(self, file):
+        if os.path.isfile(file):
+            return True
+
         # Check if the string is a valid UUID
         if isValidUUID(file):
             return False


### PR DESCRIPTION
…cal image errors out: "Invalid value for maskImage parameter"