### PR TITLE
RD-532: [Python SDK] photoMaker with numberResults=0 fails with: KeyE…

### DIFF
--- a/runware/base.py
+++ b/runware/base.py
@@ -225,7 +225,7 @@ class RunwareBase:
                     if image_uuid not in unique_results:
                         unique_results[image_uuid] = made_photo
 
-                if len(unique_results) >= numberOfResults:
+                if 0 < numberOfResults <= len(unique_results):
                     del self._globalMessages[task_uuid]
                     resolve(list(unique_results.values()))
                     return True


### PR DESCRIPTION
…rror: '2cf2ce8c-a59a-46d9-a06d-53d0ec143bbb'