### PR TITLE
allow extraArgs for IImageInference tasks to accept arguments and allow logging them

### DIFF
--- a/runware/base.py
+++ b/runware/base.py
@@ -444,6 +444,12 @@ class RunwareBase:
                 request_object["promptWeighting"] = requestImage.promptWeighting
             if requestImage.maskMargin:
                 request_object["maskMargin"] = requestImage.maskMargin
+            if hasattr(requestImage, 'extraArgs'):
+                # if extraArgs is present, and a dictionary, we will add its attributes to the request.
+                # these may contain options used for public beta testing.
+                if isinstance(requestImage.extraArgs, dict):
+                    request_object.update(requestImage.extraArgs)
+
             if requestImage.outputQuality:
                 request_object["outputQuality"] = requestImage.outputQuality
 

--- a/runware/types.py
+++ b/runware/types.py
@@ -468,6 +468,7 @@ class IImageInference:
     outpaint: Optional[IOutpaint] = None
     instantID: Optional[IInstantID] = None
     ipAdapters: Optional[List[IIpAdapter]] = field(default_factory=list)
+    extraArgs: Optional[Dict[str, Any]] = field(default_factory=dict)
 
     def __post_init__(self):
         self.validate_clip_skip()


### PR DESCRIPTION
This is mostly for public betas where we want to invite people to try new features without having those features directly supported in the SDK.