### PR TITLE
rename pipelineOptions to acceleratorOptions and make options consistent with rest api implementation

### DIFF
--- a/runware/base.py
+++ b/runware/base.py
@@ -360,8 +360,8 @@ class RunwareBase:
                 request_object["CFGScale"] = requestImage.CFGScale
             if requestImage.seedImage:
                 request_object["seedImage"] = requestImage.seedImage
-            if requestImage.pipelineOptions:
-                pipeline_options_dict = {k: v for k, v in vars(requestImage.pipelineOptions).items() if v is not None}
+            if requestImage.acceleratorOptions:
+                pipeline_options_dict = {k: v for k, v in vars(requestImage.acceleratorOptions).items() if v is not None}
                 request_object.update(pipeline_options_dict)
 
             if requestImage.maskImage:

--- a/runware/types.py
+++ b/runware/types.py
@@ -326,13 +326,13 @@ class IIpAdapter:
 
 
 @dataclass
-class IPipelineOptions:
-    teacache: Optional[bool] = None
-    teacache_distance: Optional[float] = None
-    deepcache: Optional[bool] = None
-    deepcache_interval: Optional[float] = None
-    deepcache_branch_id: Optional[int] = None
-    deepcache_skip_mode: Optional[str] = None
+class IAcceleratorOptions:
+    teaCache: Optional[bool] = None
+    teaCacheDistance: Optional[float] = None
+    deepCache: Optional[bool] = None
+    deepCacheInterval: Optional[float] = None
+    deepCacheBranch_id: Optional[int] = None
+    deepCacheSkip_mode: Optional[str] = None
 
 
 @dataclass
@@ -350,7 +350,7 @@ class IImageInference:
     strength: Optional[float] = None
     height: Optional[int] = None
     width: Optional[int] = None
-    pipelineOptions: Optional[IPipelineOptions] = None
+    acceleratorOptions: Optional[IAcceleratorOptions] = None
     steps: Optional[int] = None
     scheduler: Optional[str] = None
     seed: Optional[int] = None


### PR DESCRIPTION
Enables teaCache and deepCache.