### PR TITLE
fix: allow to pass zero value for CFGScale

### DIFF
--- a/runware/base.py
+++ b/runware/base.py
@@ -356,7 +356,7 @@ class RunwareBase:
 
             if requestImage.negativePrompt:
                 request_object["negativePrompt"] = requestImage.negativePrompt
-            if requestImage.CFGScale:
+            if requestImage.CFGScale is not None:
                 request_object["CFGScale"] = requestImage.CFGScale
             if requestImage.seedImage:
                 request_object["seedImage"] = requestImage.seedImage


### PR DESCRIPTION
Hi there,
I'm experiment some model. As I see that it requires pass 0 as CFG scale. Otherwise, the quality of image generation is so bad. I guess the server will have a default value for this. So this merge is to fix this issue.
Hope it will be merged soon.
Thanks