### PR TITLE
Handling invalid apikey error

### DIFF
--- a/runware/base.py
+++ b/runware/base.py
@@ -1075,7 +1075,7 @@ class RunwareBase:
 
         try:
             if self._invalidAPIkey:
-                raise self._invalidAPIkey
+                raise ConnectionError(self._invalidAPIkey)
 
             if not isConnected:
                 await self.connect()


### PR DESCRIPTION
This PR fixes incorrect behavior when using an invalid apikey.
Previously, when an invalid apikey was used, the process would not terminate. Now this error is handled. 