### PR TITLE
referenceImages parameter dublicate bug

### DIFF
--- a/runware/types.py
+++ b/runware/types.py
@@ -408,7 +408,6 @@ class IImageInference:
     checkNsfw: Optional[bool] = None
     negativePrompt: Optional[str] = None
     seedImage: Optional[Union[File, str]] = None
-    referenceImages: Optional[Union[File, str]] = None
     maskImage: Optional[Union[File, str]] = None
     strength: Optional[float] = None
     height: Optional[int] = None


### PR DESCRIPTION
referenceImages was dublicated in the IImageInference dataclass. 

That caused HTTP 400 errors. 