### PR TITLE
feat: model parameter support in IImageCaption with AIR ID compatibility

### DIFF
--- a/examples/image_caption.py
+++ b/examples/image_caption.py
@@ -2,7 +2,8 @@ import asyncio
 import os
 import logging
 from dotenv import load_dotenv
-from runware import Runware, IImageToText, IImageCaption, RunwareAPIError
+from runware import Runware, IImageToText, RunwareAPIError
+from runware.types import IImageCaption
 
 # Load environment variables from .env file
 load_dotenv()
@@ -17,24 +18,29 @@ async def main() -> None:
     # Connect to the Runware service
     await runware.connect()
 
-    # The image requires for the seed image. It can be the UUID of previously generated image or an a file image.
+    # The images for captioning. Can be UUIDs, URLs, base64, or file paths
     image_path = "retriever.jpg"
 
-    # With only mandatory parameters (uses default model)
-    request_image_to_text_payload = IImageCaption(inputImage=image_path)
-    
-    # With specific model using AIR ID - option 1
+    # Example 1: Using new inputImages parameter with multiple images and custom prompts
     # request_image_to_text_payload = IImageCaption(
-    #     inputImage=image_path,
+    #     inputImages=[image_path, "dalmatian.jpg"],  # Multiple images
+    #     prompts=["Describe this image in detail", "What breed is this dog?"],  # Custom prompts
     #     includeCost=True,
     #     model="runware:150@1",  # AIR ID for image captioning model version 1
     # )
     
-    #Alternative: With specific model using AIR ID - option 2
+    # Example 2: Using new inputImages parameter with single image and default prompt
+    # request_image_to_text_payload = IImageCaption(
+    #     inputImages=[image_path],  # Single image in array
+    #     includeCost=True,
+    #     model="runware:150@2",  # AIR ID for image captioning model version 2
+    # )
+    
+    # Example 3: Backward compatibility - using old inputImage parameter (mapped to inputImages[0])
     request_image_to_text_payload = IImageCaption(
-        inputImage=image_path,
+        inputImage=image_path,  # Old parameter for backward compatibility
         includeCost=True,
-        model="runware:150@2",  # AIR ID for image captioning model version 2
+        model="runware:150@1",
     )
 
     try:

--- a/runware/types.py
+++ b/runware/types.py
@@ -473,7 +473,9 @@ class IImageInference:
 
 @dataclass
 class IImageCaption:
-    inputImage: Optional[Union[File, str]] = None
+    inputImages: List[Union[File, str]] = field(default_factory=list)
+    prompts: List[str] = field(default_factory=lambda: ["Describe this image in detail"])
+    inputImage: Optional[Union[File, str]] = None  # For backward compatibility
     includeCost: bool = False
     model: Optional[Union[int, str]] = None
 


### PR DESCRIPTION
feat: model parameter support in IImageCaption with AIR ID compatibility

- Added model parameter to IImageCaption class in runware/types.py
- Add model parameter handling in imageCaption method (_requestImageToText) in runware/base.py
- Updated example examples/image_caption.py to demonstrate usage with AIR IDs (runware:150@1 and runware:150@2)
- Add inputImages parameter (array of strings) for multiple image support, where inputImages[0] = inputImage
- Add prompts parameter (array of strings) with default 'Describe this image in detail'  