### PR TITLE
fix: Make width and height parameters conditional in imageInference

### DIFF
--- a/runware/base.py
+++ b/runware/base.py
@@ -330,8 +330,6 @@ class RunwareBase:
                 "modelId": requestImage.model,
                 "positivePrompt": prompt,
                 "numberResults": requestImage.numberResults,
-                "height": requestImage.height,
-                "width": requestImage.width,
                 "taskType": ETaskType.IMAGE_INFERENCE.value,
                 **({"steps": requestImage.steps} if requestImage.steps else {}),
                 **(
@@ -443,6 +441,10 @@ class RunwareBase:
                 request_object["referenceImages"] = requestImage.referenceImages
             if requestImage.strength:
                 request_object["strength"] = requestImage.strength
+            if requestImage.height:
+                request_object["height"] = requestImage.height
+            if requestImage.width:
+                request_object["width"] = requestImage.width
             if requestImage.scheduler:
                 request_object["scheduler"] = requestImage.scheduler
             if requestImage.vae:

--- a/runware/utils.py
+++ b/runware/utils.py
@@ -40,6 +40,7 @@ BASE_RUNWARE_URLS = {
     Environment.TEST: "ws://localhost:8080",
 }
 
+
 RETRY_SDK_COUNTS = {
     "GLOBAL": 2,
     "REQUEST_IMAGES": 2,


### PR DESCRIPTION
- Fix issue where width and height parameters were always sent to API even when None
- Only include width and height in API request when they have actual values
- Prevents 'unsupported parameter' errors for models that don't support dimensions
- Maintains compatibility with models that do support custom dimensions