### PR TITLE
Add inputAudios support for OmniHuman video inference

### DIFF
--- a/runware/base.py
+++ b/runware/base.py
@@ -1431,19 +1431,23 @@ class RunwareBase:
             "taskType": ETaskType.VIDEO_INFERENCE.value,
             "taskUUID": requestVideo.taskUUID,
             "model": requestVideo.model,
-            "positivePrompt": requestVideo.positivePrompt.strip(),
             "numberResults": requestVideo.numberResults,
         }
+        
+        # Only add positivePrompt if it's not None
+        if requestVideo.positivePrompt is not None:
+            request_object["positivePrompt"] = requestVideo.positivePrompt.strip()
 
         self._addOptionalVideoFields(request_object, requestVideo)
         self._addVideoImages(request_object, requestVideo)
         self._addProviderSettings(request_object, requestVideo)
+        
         return request_object
 
     def _addOptionalVideoFields(self, request_object: Dict[str, Any], requestVideo: IVideoInference) -> None:
         optional_fields = [
             "outputType", "outputFormat", "outputQuality", "uploadEndpoint",
-            "includeCost", "negativePrompt", "fps", "steps", "seed",
+            "includeCost", "negativePrompt", "inputAudios", "fps", "steps", "seed",
             "CFGScale", "seedImage", "duration", "width", "height",
         ]
 

--- a/runware/types.py
+++ b/runware/types.py
@@ -676,6 +676,8 @@ class IBytedanceProviderSettings(BaseProviderSettings):
     @property
     def provider_key(self) -> str:
         return "bytedance"
+    
+    
 
 
 @dataclass
@@ -725,7 +727,7 @@ VideoProviderSettings = IKlingAIProviderSettings | IGoogleProviderSettings | IMi
 @dataclass
 class IVideoInference:
     model: str
-    positivePrompt: str
+    positivePrompt: Optional[str] = None
     duration: float | None = None
     width: int | None = None
     height: int | None = None
@@ -739,6 +741,7 @@ class IVideoInference:
     negativePrompt: Optional[str] = None
     frameImages: Optional[List[Union[IFrameImage, str]]] = field(default_factory=list)
     referenceImages: Optional[List[Union[str, File]]] = field(default_factory=list)
+    inputAudios: Optional[List[str]] = None
     fps: Optional[int] = None
     steps: Optional[int] = None
     seed: Optional[int] = None


### PR DESCRIPTION
Add inputAudios support for OmniHuman (bytedance:5@1) video inference
- Add inputAudios as optional field in IVideoInference dataclass
- Make positivePrompt optional in IVideoInference
- Support for bytedance:5@1 model with audio input