### PR TITLE
chore: exclude tests from library packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "Code": "https://github.com/runware/sdk-python",
         "Issue tracker": "https://github.com/runware/sdk-python/issues",
     },
-    packages=find_packages(),
+    packages=find_packages(exclude=("tests",)),
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "Code": "https://github.com/runware/sdk-python",
         "Issue tracker": "https://github.com/runware/sdk-python/issues",
     },
-    packages=find_packages(exclude=("tests",)),
+    packages=find_packages(exclude=("tests", "tests.*")),
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION
In addition to a cleaner package, those changes avoid conflicts when users have a `tests/` directory with no `__init__.py`.

In such case python tries to import things in the `tests` package the sdk provides currently.