### PR TITLE
Added support for Sync 3models

### DIFF
--- a/runware/types.py
+++ b/runware/types.py
@@ -1710,10 +1710,15 @@ class IActiveSpeakerDetection(SerializableMixin):
         for idx, boundingBoxes in enumerate(self.boundingBoxes):
             if boundingBoxes is None:
                 continue
-            if len(boundingBoxes) != 4 or not all(type(ele) == float for ele in boundingBoxes):
+            if not isinstance(boundingBoxes, (list, tuple)) or len(boundingBoxes) != 4:
                 raise ValueError(
                     f"boundingBoxes[{idx}] must be null or [x1, y1, x2, y2] with float values."
                 )
+            if not all(isinstance(ele, (int, float)) for ele in boundingBoxes):
+                raise ValueError(
+                    f"boundingBoxes[{idx}] must be null or [x1, y1, x2, y2] with float values."
+                )
+            self.boundingBoxes[idx] = [float(ele) for ele in boundingBoxes]
 
 
 @dataclass
@@ -1738,6 +1743,8 @@ class ISyncProviderSettings(BaseProviderSettings):
             self.activeSpeakerDetection = IActiveSpeakerDetection(**self.activeSpeakerDetection)
 
         if self.segments:
+            if isinstance(self.segments, dict):
+                self.segments = [self.segments]
             self.segments = [
                 ISegment(**segment) if isinstance(segment, dict) else segment
                 for segment in self.segments

--- a/runware/types.py
+++ b/runware/types.py
@@ -906,12 +906,18 @@ class ISettings(SerializableMixin):
     # Video
     draft: Optional[bool] = None
     audio: Optional[bool] = None
+    syncMode: Optional[str] = None
+    mode: Optional[str] = None
+    emotion: Optional[str] = None
     voiceDescription: Optional[str] = None
     style: Optional[str] = None
     thinking: Optional[str] = None
     multiClip: Optional[bool] = None
     promptUpsampling: Optional[bool] = None
     expressiveness: Optional[str] = None
+    activeSpeakerDetection: Optional[Union["IActiveSpeakerDetection", Dict[str, Any]]] = None
+    occlusionDetection: Optional[bool] = None
+    segments: Optional[List[Union["ISegment", Dict[str, Any]]]] = None
     removeBackground: Optional[bool] = None
     backgroundColor: Optional[str] = None
     # Text
@@ -961,6 +967,15 @@ class ISettings(SerializableMixin):
             self.colorPalette = [
                 IColorPaletteEntry(**item) if isinstance(item, dict) else item
                 for item in self.colorPalette
+            ]
+        if isinstance(self.activeSpeakerDetection, dict):
+            self.activeSpeakerDetection = IActiveSpeakerDetection(**self.activeSpeakerDetection)
+        if isinstance(self.segments, dict):
+            self.segments = [ISegment(**self.segments)]
+        elif self.segments:
+            self.segments = [
+                ISegment(**segment) if isinstance(segment, dict) else segment
+                for segment in self.segments
             ]
 
     @property
@@ -1673,27 +1688,65 @@ class IRunwayProviderSettings(BaseProviderSettings):
 
 
 @dataclass
-class ISyncSegment(SerializableMixin):
+class ISegment(SerializableMixin):
     startTime: float
     endTime: float
-    ref: str
+    audio: Optional[str] = None
+    ref: Optional[str] = None
     audioStartTime: Optional[float] = None
     audioEndTime: Optional[float] = None
 
 
 @dataclass
+class IActiveSpeakerDetection(SerializableMixin):
+    autoDetect: Optional[bool] = None
+    frameNumber: Optional[int] = None
+    coordinates: Optional[List[float]] = None
+    boundingBoxes: Optional[List[Optional[List[float]]]] = None
+
+    def __post_init__(self):
+        if self.boundingBoxes is None:
+            return
+        for idx, boundingBoxes in enumerate(self.boundingBoxes):
+            if boundingBoxes is None:
+                continue
+            if len(boundingBoxes) != 4 or not all(type(ele) == float for ele in boundingBoxes):
+                raise ValueError(
+                    f"boundingBoxes[{idx}] must be null or [x1, y1, x2, y2] with float values."
+                )
+
+
+@dataclass
 class ISyncProviderSettings(BaseProviderSettings):
     syncMode: Optional[str] = None
+    mode: Optional[str] = None
+    emotion: Optional[str] = None
     editRegion: Optional[str] = None
     emotionPrompt: Optional[str] = None
     temperature: Optional[float] = None
-    activeSpeakerDetection: Optional[bool] = None
+    activeSpeakerDetection: Optional[Union[IActiveSpeakerDetection, Dict[str, Any], bool]] = None
+    occlusionDetection: Optional[bool] = None
     occlusionDetectionEnabled: Optional[bool] = None
-    segments: Optional[List[ISyncSegment]] = None
+    segments: Optional[List[Union[ISegment, Dict[str, Any]]]] = None
 
     @property
     def provider_key(self) -> str:
         return "sync"
+
+    def __post_init__(self):
+        if isinstance(self.activeSpeakerDetection, dict):
+            self.activeSpeakerDetection = IActiveSpeakerDetection(**self.activeSpeakerDetection)
+
+        if self.segments:
+            self.segments = [
+                ISegment(**segment) if isinstance(segment, dict) else segment
+                for segment in self.segments
+            ]
+
+
+ISyncSegment = ISegment
+ISyncActiveSpeakerDetection = IActiveSpeakerDetection
+ISyncSettings = ISyncProviderSettings
 
 
 AudioProviderSettings = IElevenLabsProviderSettings | IKlingAIProviderSettings | IMireloProviderSettings


### PR DESCRIPTION
### Added

- Updated **`ISettings`**:
  - `syncMode: Optional[str]`
  - `mode: Optional[str]`
  - `emotion: Optional[str]`
  - `activeSpeakerDetection: Optional[Union[IActiveSpeakerDetection, Dict[str, Any]]]`
  - `occlusionDetection: Optional[bool]`
  - `segments: Optional[List[Union[ISegment, Dict[str, Any]]]]`
  - `tts: Optional[Union[ITTSSettings, Dict[str, Any]]]`
- Added **`IActiveSpeakerDetection`** (`autoDetect`, `frameNumber`, `coordinates`, `boundingBoxes`) with validation for `boundingBoxes` entries (`null` or four numeric values).
- Added **`ISegment`** for Sync segments (`startTime`, `endTime`, `audio`, `ref`, `audioStartTime`, `audioEndTime`).
- Added **`ITTSSettings`** for Sync TTS tuning (`stability`, `similarityBoost`).
- Added compatibility aliases:
  - **`ISyncSegment = ISegment`**
  - **`ISyncActiveSpeakerDetection = IActiveSpeakerDetection`**
  - **`ISyncSettings = ISyncProviderSettings`**

### Changed

- Updated **`ISyncProviderSettings`** to include Sync 3 fields:
  - `mode: Optional[str]`
  - `emotion: Optional[str]`
  - `activeSpeakerDetection: Optional[Union[IActiveSpeakerDetection, Dict[str, Any], bool]]`
  - `occlusionDetection: Optional[bool]`
  - `segments: Optional[List[Union[ISegment, Dict[str, Any]]]]`
- Added `post_init` normalization for Sync settings so dictionary inputs are coerced to **`IActiveSpeakerDetection`** / **`ISegment`** / **`ITTSSettings`** objects.
