### PR TITLE
Added background to ISettings for imageInference

### DIFF
--- a/runware/types.py
+++ b/runware/types.py
@@ -856,6 +856,7 @@ class ISettings(SerializableMixin):
     layers: Optional[int] = None
     trueCFGScale: Optional[float] = None
     quality: Optional[str] = None
+    background: Optional[str] = None
     promptExtend: Optional[bool] = None
     editRegions: Optional[List[List[Union[IEditRegion, Dict[str, Any]]]]] = None
     sequential: Optional[bool] = None


### PR DESCRIPTION
## Added
- ISettings now includes:
   `background`: Optional[str]