### PR TITLE
Added support for 3d Inf

### DIFF
--- a/runware/base.py
+++ b/runware/base.py
@@ -2306,6 +2306,8 @@ class RunwareBase:
         }
         if request3d.positivePrompt is not None:
             request_object["positivePrompt"] = request3d.positivePrompt.strip()
+        if request3d.negativePrompt is not None:
+            request_object["negativePrompt"] = request3d.negativePrompt.strip()
         if request3d.seed is not None:
             request_object["seed"] = request3d.seed
         if request3d.numberResults is not None:

--- a/runware/types.py
+++ b/runware/types.py
@@ -874,8 +874,12 @@ class ISettings(SerializableMixin):
     texSlat: Optional[Union[ITexSlat, Dict[str, Any]]] = None
     imageAutoFix: Optional[bool] = None
     faceLimit: Optional[int] = None
+    faceCount: Optional[int] = None
     texture: Optional[bool] = None
     pbr: Optional[bool] = None
+    geometryOnly: Optional[bool] = None
+    generateType: Optional[str] = None
+    polygonType: Optional[str] = None
     textureSeed: Optional[int] = None
     textureAlignment: Optional[str] = None
     textureQuality: Optional[str] = None
@@ -1840,13 +1844,14 @@ class IVideoInference:
             self.inputs = IVideoInputs(**self.inputs)
 
 
-I3dOutputFormat = Literal["GLB", "PLY"]
+I3dOutputFormat = Literal["GLB", "PLY", "OBJ"]
 
 
 @dataclass
 class I3dInference:
     model: str
     positivePrompt: Optional[str] = None
+    negativePrompt: Optional[str] = None
     seed: Optional[int] = None
     taskUUID: Optional[str] = None
     numberResults: Optional[int] = 1

--- a/runware/types.py
+++ b/runware/types.py
@@ -1856,7 +1856,7 @@ class I3dInference:
     taskUUID: Optional[str] = None
     numberResults: Optional[int] = 1
     outputType: Optional[IOutputType] = None
-    outputFormat: Optional[I3dOutputFormat] = None  # "GLB" | "PLY"
+    outputFormat: Optional[I3dOutputFormat] = None
     outputQuality: Optional[int] = None
     includeCost: Optional[bool] = None
     deliveryMethod: str = "async"


### PR DESCRIPTION
- **`ISettings`** now includes additional `3dInference` fields:
  - `faceCount: Optional[int]`
  - `geometryOnly: Optional[bool]`
  - `generateType: Optional[str]`
  - `polygonType: Optional[str]`
- **`I3dInference`** now includes:
  - `negativePrompt: Optional[str]`
- **`I3dOutputFormat`** now supports:
  - `OBJ`