### PR TITLE
Added support for HeyGen Avatar V models

### DIFF
--- a/runware/types.py
+++ b/runware/types.py
@@ -911,6 +911,7 @@ class ISettings(SerializableMixin):
     boundingBox: Optional[List[int]] = None
     bpm: Optional[int] = None
     cache: Optional[Union[ITextInferenceCache, Dict[str, Any]]] = None
+    caption: Optional[bool] = None
     cfgIntervalEnd: Optional[float] = None
     cfgIntervalStart: Optional[float] = None
     CFGScale: Optional[float] = None
@@ -931,6 +932,7 @@ class ISettings(SerializableMixin):
     expressiveness: Optional[str] = None
     faceCount: Optional[int] = None
     faceLimit: Optional[int] = None
+    fit: Optional[str] = None
     frequencyPenalty: Optional[float] = None
     generateParts: Optional[bool] = None
     generateType: Optional[str] = None
@@ -1784,6 +1786,7 @@ class IVideoSpeechSettings(SerializableMixin):
     text: Optional[str] = None  # Text script to be converted to speech (~200 characters, not UTF-8 Encoding)
     speed: Optional[float] = None
     pitch: Optional[float] = None
+    volume: Optional[float] = None
     language: Optional[str] = None
 
     @property


### PR DESCRIPTION
## Added

- `ISettings` now includes:
  - `fit: Optional[str]` 
  - `caption: Optional[bool]` 
- `IVideoSpeechSettings` now includes:
  - `volume: Optional[float]`