### PR TITLE
Added structuredPrompt for Ideogram 4 support

### DIFF
--- a/runware/base.py
+++ b/runware/base.py
@@ -78,7 +78,6 @@ from .utils import (
     getUUID,
     get_http_url_from_ws_url,
     fileToBase64,
-    createImageFromResponse,
     createEnhancedPromptsFromResponse,
     instantiateDataclassList,
     RunwareAPIError,
@@ -320,7 +319,7 @@ class RunwareBase:
         if on_partial_callback:
             try:
                 if item.get("imageUUID"):
-                    partial_images = [createImageFromResponse(item)]
+                    partial_images = [instantiateDataclass(IImage, item)]
                     on_partial_callback(partial_images, None)
                 elif item.get("videoUUID") or item.get("mediaUUID"):
                     on_partial_callback([item], None)
@@ -1299,7 +1298,7 @@ class RunwareBase:
             results = await asyncio.wait_for(future, timeout=IMAGE_OPERATION_TIMEOUT / 1000)
             response = results[0]
             self._handle_error_response(response)
-            image = createImageFromResponse(response)
+            image = instantiateDataclass(IImage, response)
             return [image]
         except asyncio.TimeoutError:
             raise Exception(
@@ -1413,7 +1412,7 @@ class RunwareBase:
                 response = results[0]
                 self._handle_error_response(response)
                 if response.get("status") == "success" or response.get("imageUUID") is not None:
-                    image = createImageFromResponse(response)
+                    image = instantiateDataclass(IImage, response)
                     return [image]
                 return createAsyncTaskResponse(response)
             except asyncio.TimeoutError:
@@ -1440,7 +1439,7 @@ class RunwareBase:
             results = await asyncio.wait_for(future, timeout=IMAGE_OPERATION_TIMEOUT / 1000)
             response = results[0]
             self._handle_error_response(response)
-            image = createImageFromResponse(response)
+            image = instantiateDataclass(IImage, response)
             return [image]
         except asyncio.TimeoutError:
             raise Exception(
@@ -3664,6 +3663,7 @@ class RunwareBase:
                             or r.get("outputs") is not None
                         ),
                     )
+
                     for response in responses:
                         self._handle_error_response(response)
 

--- a/runware/base.py
+++ b/runware/base.py
@@ -3664,7 +3664,6 @@ class RunwareBase:
                             or r.get("outputs") is not None
                         ),
                     )
-
                     for response in responses:
                         self._handle_error_response(response)
 

--- a/runware/types.py
+++ b/runware/types.py
@@ -188,6 +188,7 @@ class IImageInferenceTextBlock:
 class IImageInferenceOutputs:
 
     textBlocks: Optional[List[IImageInferenceTextBlock]] = None
+    structuredPrompt: Optional[Dict[str, Any]] = None
 
 
 @dataclass
@@ -195,6 +196,7 @@ class IImage:
     taskType: str
     imageUUID: str
     taskUUID: str
+    status: Optional[str] = None
     seed: Optional[int] = None
     inputImageUUID: Optional[str] = None
     imageURL: Optional[str] = None
@@ -202,6 +204,7 @@ class IImage:
     imageDataURI: Optional[str] = None
     NSFWContent: Optional[bool] = None
     cost: Optional[float] = None
+    structuredPrompt: Optional[Dict[str, Any]] = None
     outputs: Optional[IImageInferenceOutputs] = None
 
 
@@ -944,6 +947,75 @@ class IMoodboard(SerializableMixin):
 
 
 @dataclass
+class IStructuredPromptElement(SerializableMixin):
+    elementType: Optional[str] = None
+    desc: Optional[str] = None
+    text: Optional[str] = None
+    bbox: Optional[List[int]] = None
+    color_palette: Optional[List[str]] = None
+
+    def serialize(self) -> Dict[str, Any]:
+        data = super().serialize()
+        if self.elementType is not None:
+            data["type"] = self.elementType
+            data.pop("elementType", None)
+        return data
+
+
+@dataclass
+class IStructuredPromptStyleDescription(SerializableMixin):
+    aesthetics: Optional[str] = None
+    lighting: Optional[str] = None
+    photo: Optional[str] = None
+    medium: Optional[str] = None
+    art_style: Optional[str] = None
+    color_palette: Optional[List[str]] = None
+
+
+@dataclass
+class IStructuredPromptCompositionalDeconstruction(SerializableMixin):
+    background: Optional[str] = None
+    elements: Optional[List[Union[IStructuredPromptElement, Dict[str, Any]]]] = None
+
+    def __post_init__(self) -> None:
+        if self.elements is None:
+            return
+        coerced: List[IStructuredPromptElement] = []
+        for item in self.elements:
+            if isinstance(item, dict):
+                d = dict(item)
+                if "type" in d and "elementType" not in d:
+                    d["elementType"] = d.pop("type")
+                coerced.append(IStructuredPromptElement(**d))
+            else:
+                coerced.append(item)
+        self.elements = coerced
+
+
+@dataclass
+class IStructuredPrompt(SerializableMixin):
+    high_level_description: Optional[str] = None
+    style_description: Optional[
+        Union[IStructuredPromptStyleDescription, Dict[str, Any]]
+    ] = None
+    compositional_deconstruction: Optional[
+        Union[IStructuredPromptCompositionalDeconstruction, Dict[str, Any]]
+    ] = None
+
+    def __post_init__(self) -> None:
+        if isinstance(self.style_description, dict):
+            self.style_description = IStructuredPromptStyleDescription(
+                **self.style_description
+            )
+        if isinstance(self.compositional_deconstruction, dict):
+            self.compositional_deconstruction = (
+                IStructuredPromptCompositionalDeconstruction(
+                    **self.compositional_deconstruction
+                )
+            )
+
+
+@dataclass
 class ISettings(SerializableMixin):
     activeSpeakerDetection: Optional[Union["IActiveSpeakerDetection", Dict[str, Any]]] = None
     addons: Optional[List[str]] = None
@@ -966,6 +1038,7 @@ class ISettings(SerializableMixin):
     colorCorrection: Optional[bool] = None
     colorFix: Optional[bool] = None
     colorPalette: Optional[List[Union[IColorPaletteEntry, Dict[str, Any]]]] = None
+    copyrightDetection: Optional[bool] = None
     compress: Optional[str] = None
     conditionOnPreviousChunks: Optional[bool] = None
     controlNetWeight: Optional[float] = None
@@ -1057,6 +1130,7 @@ class ISettings(SerializableMixin):
     sparseStructure: Optional[Union[ISparseStructure, Dict[str, Any]]] = None
     steps: Optional[int] = None
     stopSequences: Optional[List[str]] = None
+    structuredPrompt: Optional[Union[IStructuredPrompt, Dict[str, Any]]] = None
     strength: Optional[float] = None
     style: Optional[str] = None
     symmetry: Optional[str] = None
@@ -1139,6 +1213,8 @@ class ISettings(SerializableMixin):
                 IMoodboard(**item) if isinstance(item, dict) else item
                 for item in self.moodboards
             ]
+        if isinstance(self.structuredPrompt, dict):
+            self.structuredPrompt = IStructuredPrompt(**self.structuredPrompt)
         if isinstance(self.activeSpeakerDetection, dict):
             self.activeSpeakerDetection = IActiveSpeakerDetection(**self.activeSpeakerDetection)
         if isinstance(self.segments, dict):

--- a/runware/types.py
+++ b/runware/types.py
@@ -984,8 +984,10 @@ class IStructuredPromptCompositionalDeconstruction(SerializableMixin):
         for item in self.elements:
             if isinstance(item, dict):
                 d = dict(item)
-                if "type" in d and "elementType" not in d:
-                    d["elementType"] = d.pop("type")
+                if "type" in d:
+                    if "elementType" not in d:
+                        d["elementType"] = d["type"]
+                    d.pop("type", None)
                 coerced.append(IStructuredPromptElement(**d))
             else:
                 coerced.append(item)

--- a/runware/utils.py
+++ b/runware/utils.py
@@ -781,18 +781,7 @@ def createAsyncTaskResponse(response: dict) -> IAsyncTaskResponse:
 
 
 def createImageFromResponse(response: dict) -> IImage:
-    processed_fields = {}
-
-    for field in fields(IImage):
-        if field.name in response:
-            if field.type == bool or field.type == Optional[bool]:
-                processed_fields[field.name] = bool(response[field.name])
-            elif field.type == float or field.type == Optional[float]:
-                processed_fields[field.name] = float(response[field.name])
-            else:
-                processed_fields[field.name] = response[field.name]
-
-    return instantiateDataclass(IImage, processed_fields)
+    return instantiateDataclass(IImage, response)
 
 
 def createVideoToTextFromResponse(response: dict) -> IVideoToText:

--- a/runware/utils.py
+++ b/runware/utils.py
@@ -780,10 +780,6 @@ def createAsyncTaskResponse(response: dict) -> IAsyncTaskResponse:
     return instantiateDataclass(IAsyncTaskResponse, processed_fields)
 
 
-def createImageFromResponse(response: dict) -> IImage:
-    return instantiateDataclass(IImage, response)
-
-
 def createVideoToTextFromResponse(response: dict) -> IVideoToText:
     processed_fields = {}
 


### PR DESCRIPTION
### Added

- structured prompt support for `imageInference` requests via `settings.structuredPrompt`:
  - `IStructuredPrompt` (`high_level_description`, `style_description`, `compositional_deconstruction`)
  - `IStructuredPromptCompositionalDeconstruction` (`background`, `elements`)
  - `IStructuredPromptElement` (`elementType`, `desc`, `text`, `bbox`, `color_palette`); serializes `elementType` as API `type`
  - `IStructuredPromptStyleDescription` (`aesthetics`, `lighting`, `photo`, `medium`, `art_style`, `color_palette`)
  - `ISettings.structuredPrompt: Optional[Union[IStructuredPrompt, Dict[str, Any]]]` with dict coercion in `ISettings.__post_init__`
- `ISettings.copyrightDetection: Optional[bool]`
- Image inference response fields on `IImage`:
  - `status: Optional[str]`
  - `structuredPrompt: Optional[Dict[str, Any]]` (returned as plain dict, matching API shape including `type` on elements)
- `IImageInferenceOutputs.structuredPrompt: Optional[Dict[str, Any]]` when the API nests it under `outputs`

### Changed

- Removed `createImageFromResponse`
