### PR TITLE
Added dict coercion for refImages in imageInference

### DIFF
--- a/runware/types.py
+++ b/runware/types.py
@@ -1340,10 +1340,17 @@ class IInputs(SerializableMixin):
             if self.referenceImages is None:
                 self.referenceImages = self.references
         if self.referenceImages is not None:
-            self.referenceImages = [
-                IInputReference(**item) if isinstance(item, dict) else item
-                for item in self.referenceImages
-            ]
+            coerced_reference_images: List[Union[str, File, IInputReference]] = []
+            for item in self.referenceImages:
+                if isinstance(item, dict):
+                    d = dict(item)
+                    if "type" in d and "refType" not in d:
+                        d["refType"] = d["type"]
+                        d.pop("type", None)
+                    coerced_reference_images.append(IInputReference(**d))
+                else:
+                    coerced_reference_images.append(item)
+            self.referenceImages = coerced_reference_images
         if self.fonts is not None:
             self.fonts = [
                 IInputFont(**item) if isinstance(item, dict) else item

--- a/runware/types.py
+++ b/runware/types.py
@@ -1319,7 +1319,7 @@ class IInputReference(SerializableMixin):
 @dataclass
 class IInputs(SerializableMixin):
     references: Optional[List[Union[str, File]]] = None
-    referenceImages: Optional[List[Union[str, File, IInputReference]]] = None
+    referenceImages: Optional[List[Union[str, File, IInputReference, Dict[str, Any]]]] = None
     fonts: Optional[List[Union[IInputFont, Dict[str, Any]]]] = None
     image: Optional[Union[str, File]] = None
     images: Optional[List[Union[str, File]]] = None
@@ -1339,6 +1339,11 @@ class IInputs(SerializableMixin):
             )
             if self.referenceImages is None:
                 self.referenceImages = self.references
+        if self.referenceImages is not None:
+            self.referenceImages = [
+                IInputReference(**item) if isinstance(item, dict) else item
+                for item in self.referenceImages
+            ]
         if self.fonts is not None:
             self.fonts = [
                 IInputFont(**item) if isinstance(item, dict) else item

--- a/runware/types.py
+++ b/runware/types.py
@@ -1344,8 +1344,9 @@ class IInputs(SerializableMixin):
             for item in self.referenceImages:
                 if isinstance(item, dict):
                     d = dict(item)
-                    if "type" in d and "refType" not in d:
-                        d["refType"] = d["type"]
+                    if "type" in d:
+                        if "refType" not in d:
+                            d["refType"] = d["type"]
                         d.pop("type", None)
                     coerced_reference_images.append(IInputReference(**d))
                 else:


### PR DESCRIPTION
### Changed

- `IInputs.referenceImages` now accepts `Dict[str, Any]` entries and coerces them to `IInputReference` in `IInputs.__post_init__`