### PR TITLE
Added seedImage to inputs in imageInference

### DIFF
--- a/runware/base.py
+++ b/runware/base.py
@@ -777,6 +777,11 @@ class RunwareBase:
             if requestImage.inputs.image:
                 requestImage.inputs.image = await self._process_media(requestImage.inputs.image)
 
+            if requestImage.inputs.seedImage:
+                requestImage.inputs.seedImage = await self._process_media(
+                    requestImage.inputs.seedImage
+                )
+
             if requestImage.inputs.images:
                 requestImage.inputs.images = await self._process_media_list(
                     requestImage.inputs.images

--- a/runware/types.py
+++ b/runware/types.py
@@ -1349,6 +1349,7 @@ class IInputs(SerializableMixin):
     referenceImages: Optional[List[Union[str, File, IInputReference, Dict[str, Any]]]] = None
     fonts: Optional[List[Union[IInputFont, Dict[str, Any]]]] = None
     image: Optional[Union[str, File]] = None
+    seedImage: Optional[Union[str, File]] = None
     images: Optional[List[Union[str, File]]] = None
     mask: Optional[Union[str, File]] = None
     superResolutionReferences: Optional[List[Union[str, File]]] = None


### PR DESCRIPTION
### Added

- `IInputs` now includes:
  - `seedImage: Optional[Union[str, File]]`

### Changed

- `imageInference` now processes `inputs.seedImage` via `_process_media` before sending the request