### PR TITLE
Added support for Seedance Audio

### DIFF
--- a/runware/base.py
+++ b/runware/base.py
@@ -52,6 +52,7 @@ from .types import (
     IAcceleratorOptions,
     IAudio,
     IAudioInference,
+    IAudioReferenceVoice,
     IFrameImage,
     IVideoInputs,
     IVideoReferenceImage,
@@ -3429,6 +3430,23 @@ class RunwareBase:
     async def _requestAudio(self, requestAudio: "IAudioInference") -> Union[List["IAudio"], "IAsyncTaskResponse"]:
         await self.ensureConnection()
         requestAudio.taskUUID = requestAudio.taskUUID or getUUID()
+
+        if requestAudio.inputs:
+            if requestAudio.inputs.referenceAudios:
+                requestAudio.inputs.referenceAudios = await self._process_media_list(
+                    requestAudio.inputs.referenceAudios
+                )
+
+            if requestAudio.inputs.referenceImages:
+                requestAudio.inputs.referenceImages = await self._process_media_list(
+                    requestAudio.inputs.referenceImages
+                )
+
+            if requestAudio.inputs.referenceVoices:
+                for ref in requestAudio.inputs.referenceVoices:
+                    if isinstance(ref, IAudioReferenceVoice):
+                        ref.audio = await self._process_media(ref.audio)
+
         request_object = self._buildAudioRequest(requestAudio)
         
         return await self._handleInitialAudioResponse(

--- a/runware/types.py
+++ b/runware/types.py
@@ -2356,6 +2356,8 @@ class IAudioInputs(SerializableMixin):
     audios: Optional[List[str]] = None
     video: Optional[str] = None
     videos: Optional[List[str]] = None
+    referenceAudios: Optional[List[str]] = None
+    referenceImages: Optional[List[str]] = None
     referenceVoices: Optional[List[Union[IAudioReferenceVoice, Dict[str, Any]]]] = None
 
     @property


### PR DESCRIPTION

### Added

- `IAudioInputs` now includes:
  - `referenceAudios: Optional[List[str]]`
  - `referenceImages: Optional[List[str]]`

### Changed

- `audioInference` now processes `inputs.referenceAudios`, `inputs.referenceImages`, and `inputs.referenceVoices[].audio` via `_process_media` before sending the request
